### PR TITLE
Fixed bug with NamedTemporaryFile on Windows

### DIFF
--- a/xtarfile/zstd.py
+++ b/xtarfile/zstd.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from tarfile import open as tarfile_open
 from tempfile import NamedTemporaryFile
+from os import remove as os_remove
 
 try:
     import zstandard
@@ -14,29 +15,47 @@ class ZstandardTarfile:
 
     @contextmanager
     def read(self, path: str, mode: str):
-        with NamedTemporaryFile() as decompressed:
-            with open(path, 'rb') as compressed:
-                zstd = zstandard.ZstdDecompressor(**self.zstd_kwargs)
-                zstd.copy_stream(compressed, decompressed)
-            decompressed.seek(0)
-            archive = tarfile_open(mode=mode, fileobj=decompressed)
-            try:
-                yield archive
-            finally:
-                archive.close()
+        try:
+            with NamedTemporaryFile(delete=False) as decompressed:
+                with open(path, 'rb') as compressed:
+                    zstd = zstandard.ZstdDecompressor(**self.zstd_kwargs)
+                    zstd.copy_stream(compressed, decompressed)
+                decompressed.seek(0)
+                archive = tarfile_open(mode=mode, fileobj=decompressed)
+                try:
+                    yield archive
+                finally:
+                    archive.close()
+        finally:
+            # We delete it manually because otherwise on Windows
+            # it gets deleted before we move it to the output file location.
+            # This is because on Windows, file handles with the O_TEMPORARY flag
+            # (which is set if we pass `delete=True`) are deleted as soon as
+            # they're closed.
+            decompressed.close()
+            os_remove(decompressed.name)
 
     @contextmanager
     def write(self, path: str, mode: str):
-        with NamedTemporaryFile() as decompressed:
-            archive = tarfile_open(decompressed.name, mode=mode)
-            try:
-                yield archive
-            finally:
-                archive.close()
-            decompressed.seek(0)
-            with open(path, 'wb') as compressed:
-                zstd = zstandard.ZstdCompressor(**self.zstd_kwargs)
-                zstd.copy_stream(decompressed, compressed)
+        try:
+            with NamedTemporaryFile(delete=False) as decompressed:
+                archive = tarfile_open(decompressed.name, mode=mode)
+                try:
+                    yield archive
+                finally:
+                    archive.close()
+                decompressed.seek(0)
+                with open(path, 'wb') as compressed:
+                    zstd = zstandard.ZstdCompressor(**self.zstd_kwargs)
+                    zstd.copy_stream(decompressed, compressed)
+        finally:
+            # We delete it manually because otherwise on Windows
+            # it gets deleted before we move it to the output file location.
+            # This is because on Windows, file handles with the O_TEMPORARY flag
+            # (which is set if we pass `delete=True`) are deleted as soon as
+            # they're closed.
+            decompressed.close()
+            os_remove(decompressed.name)
 
 
 if zstandard is None:

--- a/xtarfile/zstd.py
+++ b/xtarfile/zstd.py
@@ -29,9 +29,9 @@ class ZstandardTarfile:
         finally:
             # We delete it manually because otherwise on Windows
             # it gets deleted before we move it to the output file location.
-            # This is because on Windows, file handles with the O_TEMPORARY flag
-            # (which is set if we pass `delete=True`) are deleted as soon as
-            # they're closed.
+            # This is because on Windows, file handles with the O_TEMPORARY
+            # flag (which is set if we pass `delete=True`) are deleted as
+            # soon as they're closed.
             decompressed.close()
             os_remove(decompressed.name)
 
@@ -51,9 +51,9 @@ class ZstandardTarfile:
         finally:
             # We delete it manually because otherwise on Windows
             # it gets deleted before we move it to the output file location.
-            # This is because on Windows, file handles with the O_TEMPORARY flag
-            # (which is set if we pass `delete=True`) are deleted as soon as
-            # they're closed.
+            # This is because on Windows, file handles with the O_TEMPORARY
+            # flag (which is set if we pass `delete=True`) are deleted as
+            # soon as they're closed.
             decompressed.close()
             os_remove(decompressed.name)
 


### PR DESCRIPTION
Changed NamedTemporaryFile to be manually deleted isntead of automatic. We delete it manually because otherwise on Windows it gets deleted before we the temp file is saved to the output file location. This is because on Windows, file handles with the O_TEMPORARY flag (which is set if we pass `delete=True`) are deleted as soon as they're closed.

See the docs at https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile

_"Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows NT or later). If delete is true (the default), the file is deleted as soon as it is closed. The returned object is always a file-like object whose file attribute is the underlying true file object. This file-like object can be used in a with statement, just like a normal file."_