### PR TITLE
Accept PathLike objects

### DIFF
--- a/xtarfile/xtarfile.py
+++ b/xtarfile/xtarfile.py
@@ -22,7 +22,7 @@ _NATIVE_FORMATS = ('gz', 'bz2', 'xz', 'tar')
 SUPPORTED_FORMATS = frozenset(chain(_HANDLERS.keys(), _NATIVE_FORMATS))
 
 
-def get_compression(path: Union[str, os.PathLike], mode: str) -> str:
+def get_compression(path: Union[str, PathLike], mode: str) -> str:
     path = fspath(path)
     for delim in (':', '|'):
         delim_index = mode.rfind(delim)

--- a/xtarfile/xtarfile.py
+++ b/xtarfile/xtarfile.py
@@ -1,7 +1,7 @@
-import os
-from typing import Union
 from itertools import chain
+from os import PathLike, fspath
 from tarfile import open as tarfile_open
+from typing import Union
 
 from xtarfile.zstd import ZstandardTarfile
 from xtarfile.lz4 import Lz4Tarfile
@@ -23,7 +23,7 @@ SUPPORTED_FORMATS = frozenset(chain(_HANDLERS.keys(), _NATIVE_FORMATS))
 
 
 def get_compression(path: Union[str, os.PathLike], mode: str) -> str:
-    path = os.fspath(path)
+    path = fspath(path)
     for delim in (':', '|'):
         delim_index = mode.rfind(delim)
         if delim_index > -1:
@@ -36,7 +36,7 @@ def get_compression(path: Union[str, os.PathLike], mode: str) -> str:
     return ''
 
 
-def xtarfile_open(path: Union[str, os.PathLike], mode: str, **kwargs):
+def xtarfile_open(path: Union[str, PathLike], mode: str, **kwargs):
     compression = get_compression(path, mode)
 
     if not compression or compression in _NATIVE_FORMATS:

--- a/xtarfile/xtarfile.py
+++ b/xtarfile/xtarfile.py
@@ -22,7 +22,8 @@ _NATIVE_FORMATS = ('gz', 'bz2', 'xz', 'tar')
 SUPPORTED_FORMATS = frozenset(chain(_HANDLERS.keys(), _NATIVE_FORMATS))
 
 
-def get_compression(path: str, mode: str) -> str:
+def get_compression(path: Union[str, os.Pathlike], mode: str) -> str:
+    path = os.fspath(path)
     for delim in (':', '|'):
         delim_index = mode.rfind(delim)
         if delim_index > -1:
@@ -36,7 +37,7 @@ def get_compression(path: str, mode: str) -> str:
 
 
 def xtarfile_open(path: Union[str, os.Pathlike], mode: str, **kwargs):
-    compression = get_compression(os.fspath(path), mode)
+    compression = get_compression(path, mode)
 
     if not compression or compression in _NATIVE_FORMATS:
         return tarfile_open(path, mode, **kwargs)

--- a/xtarfile/xtarfile.py
+++ b/xtarfile/xtarfile.py
@@ -22,7 +22,7 @@ _NATIVE_FORMATS = ('gz', 'bz2', 'xz', 'tar')
 SUPPORTED_FORMATS = frozenset(chain(_HANDLERS.keys(), _NATIVE_FORMATS))
 
 
-def get_compression(path: Union[str, os.Pathlike], mode: str) -> str:
+def get_compression(path: Union[str, os.PathLike], mode: str) -> str:
     path = os.fspath(path)
     for delim in (':', '|'):
         delim_index = mode.rfind(delim)
@@ -36,7 +36,7 @@ def get_compression(path: Union[str, os.Pathlike], mode: str) -> str:
     return ''
 
 
-def xtarfile_open(path: Union[str, os.Pathlike], mode: str, **kwargs):
+def xtarfile_open(path: Union[str, os.PathLike], mode: str, **kwargs):
     compression = get_compression(path, mode)
 
     if not compression or compression in _NATIVE_FORMATS:

--- a/xtarfile/xtarfile.py
+++ b/xtarfile/xtarfile.py
@@ -1,3 +1,5 @@
+import os
+from typing import Union
 from itertools import chain
 from tarfile import open as tarfile_open
 
@@ -33,8 +35,8 @@ def get_compression(path: str, mode: str) -> str:
     return ''
 
 
-def xtarfile_open(path: str, mode: str, **kwargs):
-    compression = get_compression(path, mode)
+def xtarfile_open(path: Union[str, os.Pathlike], mode: str, **kwargs):
+    compression = get_compression(os.fspath(path), mode)
 
     if not compression or compression in _NATIVE_FORMATS:
         return tarfile_open(path, mode, **kwargs)


### PR DESCRIPTION
Currently xtartfile.open will error if given a pathlib.Path object, due to the get_compression function expecting a str and calling .rfind on it.